### PR TITLE
Fix Logger minutes output

### DIFF
--- a/structures/Logger.js
+++ b/structures/Logger.js
@@ -13,14 +13,13 @@ class Logger {
     this.logger.log({
       level: "info",
       message:
-        `${d.getHours()}:${
-          d.getMinutes
-        } - ${d.getDate()}:${d.getMonth()}:${d.getFullYear()} | Info: ` + Text,
+        `${d.getHours()}:${d.getMinutes()} - ${d.getDate()}:${d.getMonth()}:${d.getFullYear()} | Info: ` +
+        Text,
     });
     console.log(
       colors.green(
-        `${d.getDate()}:${d.getMonth()}:${d.getFullYear()} - ${d.getHours()}:${d.getMinutes()}`
-      ) + colors.yellow(" | Info: " + Text)
+        `${d.getDate()}:${d.getMonth()}:${d.getFullYear()} - ${d.getHours()}:${d.getMinutes()}`,
+      ) + colors.yellow(" | Info: " + Text),
     );
   }
 }


### PR DESCRIPTION
## Summary
- fix logging message template with `d.getMinutes()` call

## Testing
- `npm run format`

