### PR TITLE
Add Jest tests for TimeString utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,18 @@ If you have major coding issues with this bot, please join and ask for help.
 [![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/import/github/SudhanPlayz/Discord-MusicBot)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/SudhanPlayz/Discord-MusicBot)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 [![Run on Repl.it](https://repl.it/badge/github/SudhanPlayz/Discord-MusicBot)](https://repl.it/github/SudhanPlayz/Discord-MusicBot)
+
 [![Docker Pulls](https://img.shields.io/docker/pulls/darrenofficial/dmusicbot.svg)](https://hub.docker.com/r/darrenofficial/dmusicbot/)
 
 > Note: If you are hosting your bot in heroku, Please consider upgrading your dyno for running dashboard & bot simultaneously because in free dyno it'll run out of memory(as there are two workers). If you want to run only the bot, turn off the `web` dyno.
+
+## Running tests
+
+Run `npm install` to install dependencies and execute:
+
+```bash
+npm test
+```
 
 ## ✨ Contributors
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "install-node-v14": "wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash && export NVM_DIR=\"$([ -z \"${XDG_CONFIG_HOME-}\" ] && printf %s \"${HOME}/.nvm\" || printf %s \"${XDG_CONFIG_HOME}/nvm\")\" && [ -s \"$NVM_DIR/nvm.sh\" ] && \\. \"$NVM_DIR/nvm.sh\" && nvm install 14 && nvm use 14",
     "start": "node index",
     "rm-logs": "rm Logs.log",
+    "test": "jest",
     "format": "prettier --write .",
     "prepare": "husky install"
   },
@@ -59,7 +60,8 @@
   "devDependencies": {
     "husky": "7.0.4",
     "lint-staged": "11.2.2",
-    "prettier": "2.4.1"
+    "prettier": "2.4.1",
+    "jest": "^29.7.0"
   },
   "lint-staged": {
     "*.{js,json,md}": "prettier --write"

--- a/tests/timeString.test.js
+++ b/tests/timeString.test.js
@@ -1,0 +1,11 @@
+const parseTimestring = require("../util/TimeString");
+
+describe("parseTimestring", () => {
+  test("parses hours", () => {
+    expect(parseTimestring("1h")).toBe(3600);
+  });
+
+  test("parses minutes and seconds", () => {
+    expect(parseTimestring("2m 30s")).toBe(150);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest devDependency and test script
- test `parseTimestring`
- document running tests in README

## Testing
- `npm test`
